### PR TITLE
Add centralized environment configuration

### DIFF
--- a/app/api/detectType/route.ts
+++ b/app/api/detectType/route.ts
@@ -1,11 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 
+import {
+  INTERNAL_OR_OPENAI_API_KEY,
+  SUPABASE_ANON_KEY,
+  SUPABASE_URL,
+} from '@/lib/config';
+
 export const runtime = 'nodejs';
 
-const API_KEY = process.env.INTERNAL_API_KEY || process.env.OPENAI_API_KEY;
-const SUPABASE_URL = process.env.SUPABASE_URL!;
-const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY!;
+const API_KEY = INTERNAL_OR_OPENAI_API_KEY;
 
 const createSupabaseClient = (token: string) =>
   createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {

--- a/app/api/processImagePDF/route.ts
+++ b/app/api/processImagePDF/route.ts
@@ -4,6 +4,7 @@ import type { ChatCompletionContentPart } from 'openai/resources/chat/completion
 import { getGuidelinesImage } from '@/lib/instructions';
 import { createSupabaseClient } from '@/lib/supabase-server';
 import { formatDateForInput } from '@/app/utils/dateFormatter';
+import { OPENAI_API_KEY } from '@/lib/config';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -245,11 +246,7 @@ export async function POST(req: NextRequest) {
       ),
     ];
 
-    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
-    
-    if (!process.env.OPENAI_API_KEY) {
-      throw new Error('OpenAI API key is not configured');
-    }
+    const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
     
     const response = await openai.chat.completions.create({
       model: 'gpt-4o',

--- a/app/api/processTextPDF/route.ts
+++ b/app/api/processTextPDF/route.ts
@@ -3,6 +3,7 @@ import { OpenAI } from 'openai';
 import { getGuidelinesText } from '@/lib/instructions';
 import { createSupabaseClient } from '@/lib/supabase-server';
 import { formatDateForInput } from '@/app/utils/dateFormatter';
+import { INTERNAL_OR_OPENAI_API_KEY, OPENAI_API_KEY } from '@/lib/config';
 
 const fileFromBuffer = (
   buffer: Buffer,
@@ -13,11 +14,10 @@ const fileFromBuffer = (
 export async function POST(req: NextRequest) {
 
   const openai = new OpenAI({
-    apiKey: process.env.OPENAI_API_KEY!,
+    apiKey: OPENAI_API_KEY,
   });
 
-  const API_KEY =
-    process.env.INTERNAL_API_KEY || process.env.OPENAI_API_KEY;
+  const API_KEY = INTERNAL_OR_OPENAI_API_KEY;
 
   let isAuthenticated = false;
 

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { Session } from '@supabase/supabase-js';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { ChevronDown, ChevronUp, Eye, EyeOff } from 'lucide-react';
+import { NEXT_PUBLIC_SITE_URL } from '@/lib/public-env';
 
 let clientSideSupabase: ReturnType<typeof createSupabaseBrowserClient> | null = null;
 
@@ -41,8 +42,8 @@ export default function LoginPage() {
   const handleGoogleLogin = async () => {
     if (!supabase) return;
 
-    const redirectUrl = process.env.NEXT_PUBLIC_SITE_URL
-      ? `${process.env.NEXT_PUBLIC_SITE_URL}/upload`
+    const redirectUrl = NEXT_PUBLIC_SITE_URL
+      ? `${NEXT_PUBLIC_SITE_URL}/upload`
       : `${window.location.origin}/upload`;
 
     await supabase.auth.signInWithOAuth({

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,6 +1,11 @@
-import { z } from 'next/dist/compiled/zod';
+'use server';
 
-const envSchema = z.object({
+import { z } from 'next/dist/compiled/zod';
+import type { ZodIssue } from 'next/dist/compiled/zod';
+
+import { publicEnv } from '@/lib/public-env';
+
+const serverEnvSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).optional(),
   OPENAI_API_KEY: z
     .string({ required_error: 'OPENAI_API_KEY is required.' })
@@ -15,32 +20,34 @@ const envSchema = z.object({
   SUPABASE_ANON_KEY: z
     .string({ required_error: 'SUPABASE_ANON_KEY is required.' })
     .min(1, 'SUPABASE_ANON_KEY cannot be empty.'),
-  NEXT_PUBLIC_SUPABASE_URL: z
-    .string({ required_error: 'NEXT_PUBLIC_SUPABASE_URL is required.' })
-    .url('NEXT_PUBLIC_SUPABASE_URL must be a valid URL.'),
-  NEXT_PUBLIC_SUPABASE_ANON_KEY: z
-    .string({ required_error: 'NEXT_PUBLIC_SUPABASE_ANON_KEY is required.' })
-    .min(1, 'NEXT_PUBLIC_SUPABASE_ANON_KEY cannot be empty.'),
-  NEXT_PUBLIC_SITE_URL: z
-    .string()
-    .url('NEXT_PUBLIC_SITE_URL must be a valid URL.')
-    .optional(),
 });
 
-const envResult = envSchema.safeParse(process.env);
-
-if (!envResult.success) {
-  const message = envResult.error.issues
-    .map((issue: { path: (string | number)[]; message: string }) => {
+const formatZodIssues = (issues: ZodIssue[]): string =>
+  issues
+    .map((issue) => {
       const path = issue.path.join('.') || 'environment';
       return `${path}: ${issue.message}`;
     })
     .join('\n');
 
-  throw new Error(`Invalid environment variables:\n${message}`);
+const serverEnvResult = serverEnvSchema.safeParse({
+  NODE_ENV: process.env.NODE_ENV,
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  INTERNAL_API_KEY: process.env.INTERNAL_API_KEY,
+  SUPABASE_URL: process.env.SUPABASE_URL,
+  SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY,
+});
+
+if (!serverEnvResult.success) {
+  throw new Error(
+    `Invalid server environment variables:\n${formatZodIssues(serverEnvResult.error.issues)}`
+  );
 }
 
-const env = envResult.data;
+const env = {
+  ...publicEnv,
+  ...serverEnvResult.data,
+};
 
 export const {
   OPENAI_API_KEY,
@@ -54,4 +61,4 @@ export const {
 
 export const INTERNAL_OR_OPENAI_API_KEY = INTERNAL_API_KEY ?? OPENAI_API_KEY;
 
-export { env };
+export { env, publicEnv };

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,57 @@
+import { z } from 'next/dist/compiled/zod';
+
+const envSchema = z.object({
+  NODE_ENV: z.enum(['development', 'test', 'production']).optional(),
+  OPENAI_API_KEY: z
+    .string({ required_error: 'OPENAI_API_KEY is required.' })
+    .min(1, 'OPENAI_API_KEY cannot be empty.'),
+  INTERNAL_API_KEY: z
+    .string({ required_error: 'INTERNAL_API_KEY cannot be empty.' })
+    .min(1, 'INTERNAL_API_KEY cannot be empty.')
+    .optional(),
+  SUPABASE_URL: z
+    .string({ required_error: 'SUPABASE_URL is required.' })
+    .url('SUPABASE_URL must be a valid URL.'),
+  SUPABASE_ANON_KEY: z
+    .string({ required_error: 'SUPABASE_ANON_KEY is required.' })
+    .min(1, 'SUPABASE_ANON_KEY cannot be empty.'),
+  NEXT_PUBLIC_SUPABASE_URL: z
+    .string({ required_error: 'NEXT_PUBLIC_SUPABASE_URL is required.' })
+    .url('NEXT_PUBLIC_SUPABASE_URL must be a valid URL.'),
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: z
+    .string({ required_error: 'NEXT_PUBLIC_SUPABASE_ANON_KEY is required.' })
+    .min(1, 'NEXT_PUBLIC_SUPABASE_ANON_KEY cannot be empty.'),
+  NEXT_PUBLIC_SITE_URL: z
+    .string()
+    .url('NEXT_PUBLIC_SITE_URL must be a valid URL.')
+    .optional(),
+});
+
+const envResult = envSchema.safeParse(process.env);
+
+if (!envResult.success) {
+  const message = envResult.error.issues
+    .map((issue: { path: (string | number)[]; message: string }) => {
+      const path = issue.path.join('.') || 'environment';
+      return `${path}: ${issue.message}`;
+    })
+    .join('\n');
+
+  throw new Error(`Invalid environment variables:\n${message}`);
+}
+
+const env = envResult.data;
+
+export const {
+  OPENAI_API_KEY,
+  INTERNAL_API_KEY,
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY,
+  NEXT_PUBLIC_SUPABASE_URL,
+  NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  NEXT_PUBLIC_SITE_URL,
+} = env;
+
+export const INTERNAL_OR_OPENAI_API_KEY = INTERNAL_API_KEY ?? OPENAI_API_KEY;
+
+export { env };

--- a/lib/public-env.ts
+++ b/lib/public-env.ts
@@ -1,0 +1,43 @@
+import { z } from 'next/dist/compiled/zod';
+import type { ZodIssue } from 'next/dist/compiled/zod';
+
+const publicEnvSchema = z.object({
+  NEXT_PUBLIC_SUPABASE_URL: z
+    .string({ required_error: 'NEXT_PUBLIC_SUPABASE_URL is required.' })
+    .url('NEXT_PUBLIC_SUPABASE_URL must be a valid URL.'),
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: z
+    .string({ required_error: 'NEXT_PUBLIC_SUPABASE_ANON_KEY is required.' })
+    .min(1, 'NEXT_PUBLIC_SUPABASE_ANON_KEY cannot be empty.'),
+  NEXT_PUBLIC_SITE_URL: z
+    .string()
+    .url('NEXT_PUBLIC_SITE_URL must be a valid URL.')
+    .optional(),
+});
+
+const formatZodIssues = (issues: ZodIssue[]): string =>
+  issues
+    .map((issue) => {
+      const path = issue.path.join('.') || 'environment';
+      return `${path}: ${issue.message}`;
+    })
+    .join('\n');
+
+const publicEnvResult = publicEnvSchema.safeParse({
+  NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
+});
+
+if (!publicEnvResult.success) {
+  throw new Error(
+    `Invalid public environment variables:\n${formatZodIssues(publicEnvResult.error.issues)}`
+  );
+}
+
+export const publicEnv = publicEnvResult.data;
+
+export const {
+  NEXT_PUBLIC_SUPABASE_URL,
+  NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  NEXT_PUBLIC_SITE_URL,
+} = publicEnv;

--- a/lib/supabase-browser.ts
+++ b/lib/supabase-browser.ts
@@ -3,21 +3,26 @@
 import { createClient } from '@supabase/supabase-js';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
+import {
+  NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  NEXT_PUBLIC_SUPABASE_URL,
+} from '@/lib/public-env';
+
 let supabaseClientCache: SupabaseClient | null = null;
 
 export const createSupabaseBrowserClient = (): SupabaseClient | null => {
   if (typeof window === 'undefined') return null;
 
   if (!supabaseClientCache) {
-    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-    if (!url || !anonKey) {
+    if (!NEXT_PUBLIC_SUPABASE_URL || !NEXT_PUBLIC_SUPABASE_ANON_KEY) {
       console.error('Missing required environment variables for authentication');
       return null;
     }
 
-    supabaseClientCache = createClient(url, anonKey);
+    supabaseClientCache = createClient(
+      NEXT_PUBLIC_SUPABASE_URL,
+      NEXT_PUBLIC_SUPABASE_ANON_KEY
+    );
   }
 
   return supabaseClientCache;

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -1,15 +1,10 @@
 import { createClient } from '@supabase/supabase-js';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from '@/lib/config';
+
 export const createSupabaseClient = (accessToken?: string): SupabaseClient => {
-  const url = process.env.SUPABASE_URL;
-  const anonKey = process.env.SUPABASE_ANON_KEY;
-
-  if (!url || !anonKey) {
-    throw new Error('Missing SUPABASE_URL or SUPABASE_ANON_KEY.');
-  }
-
-  return createClient(url, anonKey, {
+  return createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
     global: {
       headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
     },

--- a/types/next-compiled-zod.d.ts
+++ b/types/next-compiled-zod.d.ts
@@ -1,0 +1,3 @@
+declare module 'next/dist/compiled/zod' {
+  export const z: any;
+}


### PR DESCRIPTION
## Summary
- add a lib/config module that validates required environment variables with Next.js' bundled zod and exports the parsed values
- switch API routes and the Supabase server helper to use the centralized configuration instead of direct process.env access
- declare the next/dist/compiled/zod module so TypeScript can consume Next.js' bundled zod types

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3fc5e85d48324869c1f40f3f90ecb