### PR TITLE
Add Doctr OCR microservice and proxy integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ LOCAL_LLM_ENDPOINT=http://localhost:8000
 
 # Optional: Custom API endpoints
 NEXT_PUBLIC_API_BASE_URL=http://localhost:3000
+
+# OCR microservice proxy
+OCR_SERVICE_URL=http://localhost:8000
 ```
 
 **Where to get these magical keys:**
@@ -165,6 +168,47 @@ yarn dev
 ```
 
 Visit [http://localhost:3000](http://localhost:3000) and witness the magic!
+
+### 🧾 OCR Microservice (DocTR + Flask)
+
+1. Build the containerized service:
+   ```bash
+   docker build -t invoice-ocr:cpu ./services/ocr
+   ```
+2. Run the service locally:
+   ```bash
+   docker run -p 8000:8000 --name ocr invoice-ocr:cpu
+   ```
+3. Ensure the Next.js app has `OCR_SERVICE_URL=http://localhost:8000` in `.env.local` so `/api/ocrProcess` can proxy requests.
+4. Health check the service:
+   ```bash
+   curl http://localhost:8000/health
+   ```
+5. Execute a PDF OCR call (replace `sample.pdf` with your file):
+   ```bash
+   curl -F "file=@sample.pdf" http://localhost:8000/ocr/pdf
+   ```
+
+Sample response snippet:
+```json
+{
+  "ok": true,
+  "file_name": "sample.pdf",
+  "pages": 2,
+  "duration_ms": 8421,
+  "normalized": [
+    {
+      "page_index": 0,
+      "text": "Invoice Number 12345",
+      "lines": [
+        { "text": "Invoice Number 12345", "confidence": 0.94 }
+      ]
+    }
+  ]
+}
+```
+
+The `/api/ocrProcess` route forwards files to the Flask service with a 180s timeout and bubbles up detailed error states (`ocr_timeout`, `ocr_failed`, `file_too_large`).
 
 ### 🚀 Production Deployment
 

--- a/app/api/ocrProcess/route.ts
+++ b/app/api/ocrProcess/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const DEFAULT_MAX_FILE_MB = 20;
+const REQUEST_TIMEOUT_MS = 180_000;
+
+export async function POST(request: NextRequest) {
+  const serviceUrl = process.env.OCR_SERVICE_URL;
+  if (!serviceUrl) {
+    return NextResponse.json({ ok: false, error: 'ocr_service_unconfigured' }, { status: 500 });
+  }
+
+  const formData = await request.formData();
+  const file = formData.get('file');
+
+  if (!file || !(file instanceof File)) {
+    return NextResponse.json({ ok: false, error: 'file_missing' }, { status: 400 });
+  }
+
+  if (file.size === 0) {
+    return NextResponse.json({ ok: false, error: 'file_empty' }, { status: 400 });
+  }
+
+  const maxFileMb = Number(process.env.OCR_MAX_FILE_MB ?? DEFAULT_MAX_FILE_MB);
+  const maxBytes = maxFileMb * 1024 * 1024;
+  if (Number.isFinite(maxBytes) && file.size > maxBytes) {
+    return NextResponse.json(
+      { ok: false, error: 'file_too_large', details: { limit_mb: maxFileMb } },
+      { status: 400 }
+    );
+  }
+
+  const forwardFormData = new FormData();
+  forwardFormData.append('file', file);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  let upstreamResponse: Response;
+  try {
+    const normalizedUrl = serviceUrl.endsWith('/') ? serviceUrl.slice(0, -1) : serviceUrl;
+    upstreamResponse = await fetch(`${normalizedUrl}/ocr/pdf`, {
+      method: 'POST',
+      body: forwardFormData,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    clearTimeout(timeout);
+    if ((error as Error).name === 'AbortError') {
+      return NextResponse.json({ ok: false, error: 'ocr_timeout' }, { status: 504 });
+    }
+
+    return NextResponse.json({ ok: false, error: 'ocr_failed', details: { message: String(error) } }, { status: 502 });
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const contentType = upstreamResponse.headers.get('content-type') ?? '';
+  const isJson = contentType.includes('application/json');
+
+  if (!upstreamResponse.ok) {
+    if (isJson) {
+      const payload = await upstreamResponse.json();
+      return NextResponse.json(payload, { status: upstreamResponse.status });
+    }
+
+    const message = await upstreamResponse.text();
+    return NextResponse.json(
+      { ok: false, error: 'ocr_failed', details: { status: upstreamResponse.status, message } },
+      { status: upstreamResponse.status }
+    );
+  }
+
+  if (isJson) {
+    const payload = await upstreamResponse.json();
+    return NextResponse.json(payload, { status: upstreamResponse.status });
+  }
+
+  return NextResponse.json(
+    { ok: false, error: 'invalid_response', details: { message: 'OCR service did not return JSON' } },
+    { status: 502 }
+  );
+}

--- a/app/lib/ocr.ts
+++ b/app/lib/ocr.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import type { OcrResponse } from '@/app/types';
+
+const OCR_ENDPOINT = '/api/ocrProcess';
+const REQUEST_TIMEOUT_MS = 180_000;
+
+/**
+ * Uploads the provided PDF to the OCR proxy route and returns the structured Doctr response.
+ * Downstream callers can enrich the invoice editor with the normalized text payload.
+ */
+export async function runOcr(file: File): Promise<OcrResponse> {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(OCR_ENDPOINT, {
+      method: 'POST',
+      body: formData,
+      signal: controller.signal,
+    });
+
+    const payload = (await response.json()) as OcrResponse;
+    if (!response.ok || !payload.ok) {
+      const error = payload.error ?? 'ocr_failed';
+      throw new Error(error);
+    }
+
+    return payload;
+  } catch (error) {
+    if ((error as Error).name === 'AbortError') {
+      throw new Error('ocr_timeout');
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Example integration idea:
+ *
+ * ```ts
+ * import { runOcr } from '@/app/lib/ocr';
+ *
+ * if (processor === 'doctr') {
+ *   const ocrResult = await runOcr(selectedFile);
+ *   // TODO: persist ocrResult.normalized or forward it to the invoice parser pipeline.
+ * }
+ * ```
+ *
+ * Recommended insertion point: after detectType identifies an image-based PDF in `app/upload/page.tsx`
+ * or immediately before invoking `/api/processDoctr` in `processInvoice`.
+ */

--- a/app/types.ts
+++ b/app/types.ts
@@ -29,3 +29,25 @@ export interface EditableInvoice {
   currency?: string;
   invoice_data: InvoiceData[];
 }
+
+export interface OcrLine {
+  text: string;
+  confidence: number | null;
+}
+
+export interface NormalizedPage {
+  page_index: number;
+  text: string;
+  lines: OcrLine[];
+}
+
+export interface OcrResponse {
+  ok: boolean;
+  file_name: string;
+  pages: number;
+  duration_ms: number;
+  doctr_raw: unknown;
+  normalized: NormalizedPage[];
+  error?: string;
+  details?: Record<string, unknown>;
+}

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -183,6 +183,7 @@ const UploadPage = () => {
         endpoint = '/api/processLocalLLM'; 
         processingMethod = 'text';
       } else if (type === 'doctr') {
+        // TODO(invoice-ocr): invoke runOcr(file) from '@/app/lib/ocr' here to fetch the Doctr payload before falling back to legacy handlers.
         endpoint = '/api/processDoctr';
         processingMethod = 'image';
       }

--- a/services/ocr/Dockerfile
+++ b/services/ocr/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libgl1 \
+        libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
+
+COPY app.py ./
+
+EXPOSE 8000
+
+CMD ["gunicorn", "-b", "0.0.0.0:8000", "-w", "1", "--timeout", "180", "app:app"]

--- a/services/ocr/app.py
+++ b/services/ocr/app.py
@@ -1,0 +1,155 @@
+import os
+import time
+from typing import Any, Dict, List
+
+import fitz  # type: ignore
+import numpy as np
+from flask import Flask, jsonify, request
+from PIL import Image
+from werkzeug.utils import secure_filename
+
+app = Flask(__name__)
+
+MAX_PAGES = int(os.getenv("MAX_PAGES", "50"))
+MAX_FILE_MB = float(os.getenv("MAX_FILE_MB", "20"))
+CONF_THRESHOLD = float(os.getenv("CONF_THRESHOLD", "0.3"))
+ZOOM_FACTOR = float(os.getenv("PDF_ZOOM", "2.0"))
+
+_OCR_PREDICTOR = None
+
+
+# Future ideas:
+# - cv2-based pre-processing (denoise, adaptive thresholding, rotation correction)
+# - Persist duration_ms/pages metrics for downstream monitoring
+# - Prompt template placeholder for OCR → LLM structured extraction pipeline
+
+def _load_predictor():
+    global _OCR_PREDICTOR
+    if _OCR_PREDICTOR is None:
+        from doctr.models import ocr_predictor
+
+        _OCR_PREDICTOR = ocr_predictor(
+            det_arch="db_resnet50",
+            reco_arch="crnn_vgg16_bn",
+            pretrained=True,
+        )
+    return _OCR_PREDICTOR
+
+
+def _error_response(message: str, status_code: int = 400, **extra: Any):
+    payload = {"ok": False, "error": message}
+    if extra:
+        payload["details"] = extra
+    response = jsonify(payload)
+    response.status_code = status_code
+    return response
+
+
+def _pdf_to_images(pdf_bytes: bytes) -> List[Image.Image]:
+    images: List[Image.Image] = []
+    with fitz.open(stream=pdf_bytes, filetype="pdf") as document:
+        page_count = len(document)
+        if page_count > MAX_PAGES:
+            raise ValueError("MAX_PAGE_LIMIT_EXCEEDED")
+
+        matrix = fitz.Matrix(ZOOM_FACTOR, ZOOM_FACTOR)
+        for page in document:
+            pix = page.get_pixmap(matrix=matrix)
+            mode = "RGBA" if pix.alpha else "RGB"
+            image = Image.frombytes(mode, [pix.width, pix.height], pix.samples)
+            if mode == "RGBA":
+                image = image.convert("RGB")
+            images.append(image)
+    return images
+
+
+def _build_normalized(export: Dict[str, Any]) -> List[Dict[str, Any]]:
+    normalized_pages: List[Dict[str, Any]] = []
+    pages = export.get("pages", [])
+    for page_index, page in enumerate(pages):
+        page_lines: List[Dict[str, Any]] = []
+        text_fragments: List[str] = []
+        for block in page.get("blocks", []):
+            for line in block.get("lines", []):
+                words = line.get("words", [])
+                line_text_parts = [word.get("value", "") for word in words if word.get("value")]
+                if not line_text_parts:
+                    continue
+                confidences = [word.get("confidence") for word in words if word.get("confidence") is not None]
+                avg_conf = float(sum(confidences) / len(confidences)) if confidences else None
+                if avg_conf is not None and avg_conf < CONF_THRESHOLD:
+                    continue
+                line_text = " ".join(line_text_parts)
+                text_fragments.append(line_text)
+                page_lines.append(
+                    {
+                        "text": line_text,
+                        "confidence": round(avg_conf, 4) if avg_conf is not None else None,
+                    }
+                )
+        normalized_pages.append(
+            {
+                "page_index": page_index,
+                "text": "\n".join(text_fragments),
+                "lines": page_lines,
+            }
+        )
+    return normalized_pages
+
+
+@app.get("/health")
+def health():
+    return jsonify({"ok": True})
+
+
+@app.post("/ocr/pdf")
+def ocr_pdf():
+    if "file" not in request.files:
+        return _error_response("file_missing", 400)
+
+    uploaded = request.files["file"]
+    filename = secure_filename(uploaded.filename or "document.pdf")
+
+    pdf_bytes = uploaded.read()
+    if not pdf_bytes:
+        return _error_response("file_empty", 400)
+
+    file_size_mb = len(pdf_bytes) / (1024 * 1024)
+    if file_size_mb > MAX_FILE_MB:
+        return _error_response("file_too_large", 400, limit_mb=MAX_FILE_MB)
+
+    start_time = time.time()
+
+    try:
+        images = _pdf_to_images(pdf_bytes)
+    except ValueError as exc:  # MAX_PAGE_LIMIT_EXCEEDED
+        if str(exc) == "MAX_PAGE_LIMIT_EXCEEDED":
+            return _error_response("page_limit_exceeded", 400, limit=MAX_PAGES)
+        return _error_response("pdf_render_failed", 400, reason=str(exc))
+    except Exception as exc:  # noqa: BLE001
+        return _error_response("pdf_render_failed", 500, reason=str(exc))
+
+    try:
+        predictor = _load_predictor()
+        np_images = [np.array(img.convert("RGB")) for img in images]
+        result = predictor(np_images)
+        exported = result.export()
+    except Exception as exc:  # noqa: BLE001
+        return _error_response("ocr_failed", 500, reason=str(exc))
+
+    duration_ms = int((time.time() - start_time) * 1000)
+
+    response_payload = {
+        "ok": True,
+        "file_name": filename,
+        "pages": len(images),
+        "duration_ms": duration_ms,
+        "doctr_raw": exported,
+        "normalized": _build_normalized(exported),
+    }
+
+    return jsonify(response_payload)
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/services/ocr/requirements.txt
+++ b/services/ocr/requirements.txt
@@ -1,0 +1,9 @@
+Flask==3.0.3
+gunicorn==21.2.0
+python-doctr[torch]==0.7.1
+torch==2.2.2
+torchvision==0.17.2
+opencv-python-headless==4.9.0.80
+PyMuPDF==1.24.1
+Pillow==10.3.0
+numpy==1.26.4


### PR DESCRIPTION
## Summary
- add a Flask + DocTR OCR microservice with PDF rendering limits, Docker assets, and structured JSON output
- introduce a Next.js `/api/ocrProcess` proxy with typed helpers so the UI can forward PDF uploads to the microservice
- document local OCR setup, response examples, and note the UI insertion point for future wiring

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3fce164508324af0f4286b4903fff