### PR TITLE
feat: add structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 # OpenAI Configuration
 OPENAI_API_KEY=your_openai_api_key
 
+# Logging (optional)
+LOG_LEVEL=debug
+NEXT_PUBLIC_LOG_LEVEL=debug
+
 # Optional: Local LLM endpoint (if you're running your own)
 LOCAL_LLM_ENDPOINT=http://localhost:8000
 
@@ -165,6 +169,20 @@ yarn dev
 ```
 
 Visit [http://localhost:3000](http://localhost:3000) and witness the magic!
+
+### 📜 Logging
+
+We ship a lightweight [Pino](https://getpino.io/)-style logger that emits **structured JSON** events from both the API routes and client utilities.
+
+- **Development**: keep the default `debug` level (set via `LOG_LEVEL` or `NEXT_PUBLIC_LOG_LEVEL`) and pretty-print the output with your favourite tool:
+  ```bash
+  npm run dev | npx pino-pretty
+  # or
+  npm run dev | jq
+  ```
+- **Production**: the logger automatically falls back to the `info` level. Forward the JSON lines straight to your log shipper (e.g. Loki, Datadog, ELK) for structured querying. Adjust verbosity with `LOG_LEVEL=warn` or `LOG_LEVEL=error` as needed.
+
+Sensitive fields such as tokens and passwords are redacted automatically. Import `logger` from `@/lib/logger` anywhere in the codebase and call `logger.info`, `logger.warn`, or `logger.error` instead of `console.*`.
 
 ### 🚀 Production Deployment
 

--- a/app/api/detectType/route.ts
+++ b/app/api/detectType/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import logger from '@/lib/logger';
 
 export const runtime = 'nodejs';
 
@@ -69,7 +70,7 @@ export async function POST(req: NextRequest) {
       textPreview: `Estimated ${estimatedPages} pages (${isLikelyImage ? 'image-based' : 'text-based'})`,
     });
   } catch (err) {
-    console.error('PDF analysis error:', err);
+    logger.error({ err }, 'PDF analysis error');
     return NextResponse.json({ error: 'Failed to analyze PDF' }, { status: 500 });
   }
 }

--- a/app/api/processImagePDF/route.ts
+++ b/app/api/processImagePDF/route.ts
@@ -8,6 +8,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { chromium } from 'playwright';
+import logger from '@/lib/logger';
 
 declare global {
   interface Window {
@@ -80,7 +81,6 @@ const convertPdfToImages = async (pdfBuffer: Buffer): Promise<string[]> => {
                 
                 window.pdfRendered = true;
               } catch (error) {
-                console.error('PDF rendering error:', error);
                 window.pdfError = error;
               }
             }
@@ -109,7 +109,7 @@ const convertPdfToImages = async (pdfBuffer: Buffer): Promise<string[]> => {
         });
         imagePaths.push(path.join(tempDir, `page-${i + 1}.png`));
       } catch (error) {
-        console.warn('Failed to screenshot canvas, skipping:', error);
+        logger.warn({ error }, 'Failed to screenshot canvas, skipping page screenshot');
         continue;
       }
     }
@@ -123,7 +123,7 @@ const convertPdfToImages = async (pdfBuffer: Buffer): Promise<string[]> => {
     return imagePaths;
 
   } catch (error) {
-    console.error('PDF processing error:', error);
+    logger.error({ error }, 'PDF processing error');
     throw error;
   }
 };
@@ -304,21 +304,25 @@ export async function POST(req: NextRequest) {
     } catch (parseError) {
       throw new Error(`Failed to parse JSON from OpenAI response: ${(parseError as Error).message}`);
     }
-  } catch (_) {
+  } catch (error) {
     if (imagePaths && imagePaths.length > 0) {
       cleanupTempFiles(imagePaths);
     }
-    
-    const errorMessage = (_ as Error).message || 'Unexpected server error';
-    console.error('ProcessImagePDF Error:', {
-      message: errorMessage,
-      stack: (_ as Error).stack,
-      name: (_ as Error).name,
-      timestamp: new Date().toISOString()
-    });
-    
+
+    const normalizedError = error instanceof Error ? error : new Error(String(error));
+    const errorMessage = normalizedError.message || 'Unexpected server error';
+    logger.error(
+      {
+        message: errorMessage,
+        stack: normalizedError.stack,
+        name: normalizedError.name,
+        timestamp: new Date().toISOString(),
+      },
+      'ProcessImagePDF error',
+    );
+
     return NextResponse.json(
-      { 
+      {
         error: errorMessage,
         fallbackData: {
           id: crypto.randomUUID(),

--- a/app/api/processTextPDF/route.ts
+++ b/app/api/processTextPDF/route.ts
@@ -3,6 +3,7 @@ import { OpenAI } from 'openai';
 import { getGuidelinesText } from '@/lib/instructions';
 import { createSupabaseClient } from '@/lib/supabase-server';
 import { formatDateForInput } from '@/app/utils/dateFormatter';
+import logger from '@/lib/logger';
 
 const fileFromBuffer = (
   buffer: Buffer,
@@ -37,7 +38,7 @@ export async function POST(req: NextRequest) {
         } = await supabase.auth.getUser();
         if (user && !error) isAuthenticated = true;
       } catch (err) {
-        console.error('Supabase auth error:', err);
+        logger.error({ err }, 'Supabase auth error');
       }
     }
   }
@@ -102,7 +103,7 @@ export async function POST(req: NextRequest) {
       }
 
       if (status.status === 'failed') {
-        console.error('OpenAI run failed:', status.last_error);
+        logger.error({ lastError: status.last_error }, 'OpenAI run failed');
         throw new Error(`OpenAI processing failed: ${status.last_error?.message || 'Unknown error'}`);
       }
 
@@ -119,7 +120,7 @@ export async function POST(req: NextRequest) {
     ) as { type: 'text'; text: { value: string } } | undefined;
 
     if (!msg?.text?.value) {
-      console.error('No valid message returned from assistant');
+      logger.error('No valid message returned from assistant');
       throw new Error('No valid message returned from assistant');
     }
 
@@ -128,15 +129,15 @@ export async function POST(req: NextRequest) {
     const tryExtractJson = (text: string): unknown => {
       const match = text.match(/{[\s\S]*}/);
       if (!match) {
-        console.error('No JSON object found in response:', text);
+        logger.error({ response: text }, 'No JSON object found in assistant response');
         throw new Error('No JSON object found in assistant response');
       }
       try {
         const parsed = JSON.parse(match[0]);
         return parsed;
       } catch (err) {
-        console.error('JSON parsing failed:', err);
-        console.error('Attempted to parse:', match[0]);
+        logger.error({ err }, 'JSON parsing failed');
+        logger.error({ attempted: match[0] }, 'Attempted to parse invalid JSON');
         throw new Error(
           `Failed to parse JSON: ${(err as Error).message}`
         );
@@ -158,11 +159,14 @@ export async function POST(req: NextRequest) {
       fulfillment_date?: string;
     };
     if (!result_obj.seller || !result_obj.buyer || !Array.isArray(result_obj.invoice_data)) {
-      console.warn('Missing required fields in parsed result:', {
-        hasSeller: !!result_obj.seller,
-        hasBuyer: !!result_obj.buyer,
-        hasInvoiceData: Array.isArray(result_obj.invoice_data)
-      });
+      logger.warn(
+        {
+          hasSeller: !!result_obj.seller,
+          hasBuyer: !!result_obj.buyer,
+          hasInvoiceData: Array.isArray(result_obj.invoice_data),
+        },
+        'Missing required fields in parsed result',
+      );
     }
 
     if (result_obj.issue_date) {
@@ -177,7 +181,7 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json(result_obj);
   } catch (err) {
-    console.error('Processing error:', err);
+    logger.error({ err }, 'Processing error');
     return NextResponse.json(
       { error: 'Failed to process PDF with OpenAI' },
       { status: 500 }

--- a/app/api/processed/item/route.ts
+++ b/app/api/processed/item/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createSupabaseClient } from '@/lib/supabase-server';
+import logger from '@/lib/logger';
 
 export async function DELETE(req: NextRequest) {
   const token = req.headers.get('authorization')?.replace('Bearer ', '');
@@ -30,7 +31,7 @@ export async function DELETE(req: NextRequest) {
       .single();
 
     if (fetchError) {
-      console.error('Fetch error:', fetchError);
+      logger.error({ fetchError }, 'Fetch error during processed item deletion');
       return NextResponse.json({ error: 'Invoice not found' }, { status: 404 });
     }
 
@@ -52,13 +53,13 @@ export async function DELETE(req: NextRequest) {
       .eq('user_id', user.id);
 
     if (updateError) {
-      console.error('Update error:', updateError);
+      logger.error({ updateError }, 'Update error during processed item deletion');
       return NextResponse.json({ error: updateError.message }, { status: 500 });
     }
 
     return NextResponse.json({ success: true });
   } catch (err) {
-    console.error('Delete error:', err);
+    logger.error({ err }, 'Delete error in processed item route');
     return NextResponse.json({ error: 'Failed to process the request' }, { status: 500 });
   }
-} 
+}

--- a/app/api/saveProcessedData/route.ts
+++ b/app/api/saveProcessedData/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createSupabaseClient } from '@/lib/supabase-server';
 import { InvoiceData } from '@/app/types';
+import logger from '@/lib/logger';
 
 const convertToISODate = (dateString: string): string | null => {
   if (!dateString || dateString.trim() === '') return null;
@@ -28,7 +29,7 @@ const convertToISODate = (dateString: string): string | null => {
     
     return null;
   } catch (error) {
-    console.warn('Date conversion failed for:', dateString, error);
+    logger.warn({ dateString, error }, 'Date conversion failed');
     return null;
   }
 };
@@ -37,7 +38,7 @@ export async function POST(req: NextRequest) {
   const token = req.headers.get('authorization')?.replace('Bearer ', '');
   
   if (!token) {
-    console.error('No authorization token provided');
+    logger.error('No authorization token provided');
     return NextResponse.json({ error: 'No authorization token provided' }, { status: 401 });
   }
 
@@ -45,7 +46,7 @@ export async function POST(req: NextRequest) {
   const { data: { user }, error } = await supabase.auth.getUser();
 
   if (error || !user) {
-    console.error('Authentication error:', error);
+    logger.error({ error }, 'Authentication error');
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
@@ -55,12 +56,12 @@ export async function POST(req: NextRequest) {
     const { fields, project } = body;
 
     if (!fields || !project) {
-      console.error('Missing required fields:', { fields: !!fields, project: !!project });
+      logger.error({ hasFields: !!fields, hasProject: !!project }, 'Missing required fields');
       return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
     }
 
     if (!fields.seller?.name) {
-      console.error('Seller name is required but missing');
+      logger.error('Seller name is required but missing');
       return NextResponse.json({ error: 'Seller name is required' }, { status: 400 });
     }
 
@@ -72,12 +73,12 @@ export async function POST(req: NextRequest) {
       .single();
 
     if (projectError) {
-      console.error('Project query error:', projectError);
+      logger.error({ projectError }, 'Project query error');
       return NextResponse.json({ error: 'Database error' }, { status: 500 });
     }
 
     if (!projectData) {
-      console.error('Project not found:', project);
+      logger.error({ project }, 'Project not found');
       return NextResponse.json({ error: 'Project not found' }, { status: 404 });
     }
 
@@ -123,10 +124,10 @@ export async function POST(req: NextRequest) {
       .single();
 
     if (insertError) {
-      console.error('Database insert error:', insertError);
-      return NextResponse.json({ 
-        error: 'Database insert failed', 
-        details: insertError.message 
+      logger.error({ insertError }, 'Database insert error');
+      return NextResponse.json({
+        error: 'Database insert failed',
+        details: insertError.message
       }, { status: 500 });
     }
 
@@ -137,9 +138,9 @@ export async function POST(req: NextRequest) {
       projectName: project
     });
   } catch (err) {
-    console.error('Save error:', err);
-    return NextResponse.json({ 
-      error: 'Internal server error', 
+    logger.error({ err }, 'Save processed data error');
+    return NextResponse.json({
+      error: 'Internal server error',
       details: err instanceof Error ? err.message : 'Unknown error'
     }, { status: 500 });
   }

--- a/app/components/FinancialSummary.tsx
+++ b/app/components/FinancialSummary.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import { InvoiceData } from '@/app/types';
+import logger from '@/lib/logger';
 
 interface ProcessedItem {
   id: string;
@@ -226,7 +227,7 @@ export default function FinancialSummary({ data }: FinancialSummaryProps) {
         minimumFractionDigits: 2
       }).format(amount);
     } catch {
-      console.warn(`Invalid currency code: ${currency}, falling back to number format`);
+      logger.warn({ currency }, 'Invalid currency code, falling back to number format');
       return `${amount.toLocaleString('en-US', { minimumFractionDigits: 2 })} ${normalizedCurrency}`;
     }
   };

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import slugify from "slugify";
 import BackButton from "../components/BackButton";
 import DeleteModal from "../components/modals/DeleteModal";
 import { createSupabaseBrowserClient } from "@/lib/supabase-browser";
+import logger from "@/lib/logger";
 
 interface Project {
   id: string;
@@ -51,14 +52,14 @@ export default function DashboardPage() {
         try {
           const { data, error } = await supabase.from("projects").select("id, name");
           if (error) {
-            console.error("Error fetching projects:", error);
+            logger.error({ error }, "Error fetching projects");
             return;
           }
           if (data) {
             setProjects(data);
           }
         } catch (err) {
-          console.error("Failed to fetch projects:", err);
+          logger.error({ err }, "Failed to fetch projects");
         }
       } else if (authInitialized && !user) {
         setProjects(fakeProjects);
@@ -88,7 +89,7 @@ export default function DashboardPage() {
       });
 
       if (!res.ok) {
-        console.error("Failed to delete project:", await res.text());
+        logger.error({ response: await res.text() }, "Failed to delete project");
         alert("Failed to delete project.");
         setShowDeleteModal(null);
         return;

--- a/app/edit/page.tsx
+++ b/app/edit/page.tsx
@@ -12,6 +12,7 @@ import type { EditableInvoice } from '../types';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import slugify from 'slugify';
 import { useProcessing } from '../client-provider';
+import logger from '@/lib/logger';
 
 let clientSideSupabase: ReturnType<typeof createSupabaseBrowserClient> | null = null;
 
@@ -241,7 +242,7 @@ const EditPage = () => {
         const rawText = await response.text();
         result = JSON.parse(rawText);
       } catch (parseError) {
-        console.error('Error parsing response:', parseError);
+        logger.error({ error: parseError }, 'Error parsing response');
         throw new Error('Failed to parse API response. The server may be experiencing issues.');
       }
       
@@ -265,7 +266,7 @@ const EditPage = () => {
       setProcessingMethod('image');
       
     } catch (err) {
-      console.error('Reprocessing error:', err);
+      logger.error({ err }, 'Reprocessing error');
       setError((err as Error)?.message || 'Failed to reprocess PDF.');
     } finally {
       setIsReprocessing(false);

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -14,6 +14,7 @@ import { Pencil, Check } from 'lucide-react';
 import InvoiceCard from '@/app/components/InvoiceCard';
 import InvoiceFilters, { FilterOptions } from '@/app/components/InvoiceFilters';
 import FinancialSummary from '@/app/components/FinancialSummary';
+import logger from '@/lib/logger';
 
 interface Project {
   id: string;
@@ -240,7 +241,7 @@ export default function ProjectDetailsPage() {
         const newSlug = slugify(projectName.trim(), { lower: true, strict: true });
         router.push(`/projects/${newSlug}`);
       } catch (error) {
-        console.error('Error updating project name:', error);
+        logger.error({ error }, 'Error updating project name');
         setProjectName(project.name);
       }
     } else {

--- a/app/projects/[id]/processed/[itemId]/edit/page.tsx
+++ b/app/projects/[id]/processed/[itemId]/edit/page.tsx
@@ -13,6 +13,7 @@ import { AlertTriangle } from 'lucide-react';
 import { fakeProjects, FakeProcessedItem } from '@/app/fakeData';
 import type { EditableInvoice, InvoiceData } from '@/app/types';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import logger from '@/lib/logger';
 
 interface Project {
   id: string;
@@ -201,12 +202,12 @@ export default function EditProcessedItemPage() {
             setFields({ ...item.fields, id: item.id });
             setLoading(false);
           } catch (fakeErr) {
-            console.error('Error with demo data:', fakeErr);
+            logger.error({ error: fakeErr }, 'Error with demo data');
             throw new Error('Failed to load invoice data. Please log in to view real data.');
           }
         }
       } catch (err) {
-        console.error(err);
+        logger.error({ err }, 'Failed to load processed item data');
         setError('Failed to load data.');
         setLoading(false);
       }
@@ -308,7 +309,7 @@ export default function EditProcessedItemPage() {
       
       setTimeout(() => setSuccess(false), hasProjectChanged ? 4000 : 3000);
     } catch (err) {
-      console.error(err);
+      logger.error({ err }, 'Failed to save processed item');
       setError(err instanceof Error ? err.message : 'Failed to save changes.');
       setProjectChanging(false);
     } finally {

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, createContext, useContext } from 'react';
 import type { Session, User } from '@supabase/supabase-js';
 import type { PropsWithChildren } from 'react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import logger from '@/lib/logger';
 
 const UserContext = createContext<User | null>(null);
 const SessionContext = createContext<Session | null>(null);
@@ -18,8 +19,8 @@ export default function Providers({ children }: PropsWithChildren) {
   const [supabaseClient] = useState(() => {
     try {
       return createSupabaseBrowserClient();
-    } catch {
-      console.error('Authentication service initialization failed');
+    } catch (error) {
+      logger.error({ error }, 'Authentication service initialization failed');
       return null;
     }
   });

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -5,6 +5,7 @@ import { Upload, FileText, AlertCircle, Loader2 } from 'lucide-react';
 import { useUser } from '../providers';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { useProcessing } from '../client-provider';
+import logger from '@/lib/logger';
 
 import PdfPreviewFrame from '../components/PdfPreviewFrame';
 import ProgressModal from '../components/ProgressModal';
@@ -105,14 +106,14 @@ const UploadPage = () => {
 
         if (!res.ok) {
           const errorText = await res.text();
-          console.error('Detection request failed:', res.status, errorText);
+          logger.error({ status: res.status, error: errorText }, 'Detection request failed');
           throw new Error(`Detection request failed with status ${res.status}: ${errorText}`);
         }
         
         const data = await res.json();
         return data;
       } catch (err) {
-        console.error('Detection error:', err);
+        logger.error({ err }, 'Detection error');
         throw err;
       }
     };
@@ -133,10 +134,10 @@ const UploadPage = () => {
         }
       }
       
-      console.error('All detection attempts failed:', lastError);
+      logger.error({ error: lastError }, 'All detection attempts failed after retries');
       throw lastError || new Error('Failed after multiple attempts');
     } catch (err) {
-      console.error('All detection attempts failed:', err);
+      logger.error({ err }, 'All detection attempts failed');
       setError(`Detection failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
     } finally {
       setIsDetecting(false);

--- a/app/utils/dateFormatter.ts
+++ b/app/utils/dateFormatter.ts
@@ -1,3 +1,5 @@
+import logger from '@/lib/logger';
+
 export const formatDateForInput = (dateString: string | undefined | null): string => {
   if (!dateString || dateString.trim() === '') return '';
   
@@ -95,10 +97,10 @@ export const formatDateForInput = (dateString: string | undefined | null): strin
       return testDate.toISOString().split('T')[0];
     }
     
-    console.warn('Could not parse date:', dateString);
+    logger.warn({ dateString }, 'Could not parse date');
     return '';
   } catch (error) {
-    console.warn('Date formatting failed for:', dateString, error);
+    logger.warn({ dateString, error }, 'Date formatting failed');
     return '';
   }
 };
@@ -117,7 +119,7 @@ export const formatDateForDisplay = (dateString: string | undefined | null): str
     }
     return dateString;
   } catch (error) {
-    console.warn('Date display formatting failed for:', dateString, error);
+    logger.warn({ dateString, error }, 'Date display formatting failed');
     return dateString;
   }
-}; 
+};

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,20 @@
+import pino from 'pino';
+
+type Environment = 'development' | 'production' | 'test';
+
+const nodeEnv = (process.env.NODE_ENV as Environment | undefined) ?? 'development';
+const defaultLevel: 'debug' | 'info' = nodeEnv === 'production' ? 'info' : 'debug';
+const explicitLevel =
+  (typeof process !== 'undefined' && process.env.LOG_LEVEL) ||
+  (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_LOG_LEVEL);
+
+const logger = pino({
+  level: (explicitLevel as typeof defaultLevel | undefined) ?? defaultLevel,
+  base: {
+    service: 'invoice-ai',
+    environment: nodeEnv,
+  },
+  redact: ['authorization', 'token', 'password'],
+});
+
+export default logger;

--- a/lib/supabase-browser.ts
+++ b/lib/supabase-browser.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import logger from './logger';
 
 let supabaseClientCache: SupabaseClient | null = null;
 
@@ -13,7 +14,7 @@ export const createSupabaseBrowserClient = (): SupabaseClient | null => {
     const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
     if (!url || !anonKey) {
-      console.error('Missing required environment variables for authentication');
+      logger.error('Missing required environment variables for authentication');
       return null;
     }
 

--- a/lib/vendor/pino.ts
+++ b/lib/vendor/pino.ts
@@ -1,0 +1,151 @@
+export type LogLevel = 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace' | 'silent';
+
+export interface PinoOptions {
+  level?: LogLevel;
+  base?: Record<string, unknown> | null;
+  redact?: string[];
+}
+
+export interface Logger {
+  level: LogLevel;
+  fatal: LogMethod;
+  error: LogMethod;
+  warn: LogMethod;
+  info: LogMethod;
+  debug: LogMethod;
+  trace: LogMethod;
+  child(bindings: Record<string, unknown>): Logger;
+}
+
+export type LogInput = Record<string, unknown> | string | undefined | null;
+export type LogMethod = (messageOrData?: LogInput, maybeDataOrMessage?: LogInput) => void;
+
+const LEVEL_WEIGHT: Record<LogLevel, number> = {
+  trace: 10,
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+  fatal: 60,
+  silent: Number.POSITIVE_INFINITY,
+};
+
+const LEVEL_TO_CONSOLE: Record<Exclude<LogLevel, 'silent'>, keyof Console> = {
+  trace: 'log',
+  debug: 'log',
+  info: 'log',
+  warn: 'warn',
+  error: 'error',
+  fatal: 'error',
+};
+
+const REDACTED = '[redacted]';
+
+function normalizeInput(input: LogInput): Record<string, unknown> | undefined {
+  if (!input) {
+    return undefined;
+  }
+
+  if (typeof input === 'string') {
+    return { msg: input };
+  }
+
+  return input;
+}
+
+function redact(data: Record<string, unknown>, redactedKeys: string[]): Record<string, unknown> {
+  if (!redactedKeys.length) {
+    return data;
+  }
+
+  const clone: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    clone[key] = redactedKeys.includes(key) ? REDACTED : value;
+  }
+
+  return clone;
+}
+
+function mergeObjects(
+  base: Record<string, unknown> | null,
+  bindings: Record<string, unknown>,
+  entry: Record<string, unknown> | undefined,
+  redactedKeys: string[],
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    time: new Date().toISOString(),
+    ...(base ?? {}),
+    ...bindings,
+    ...entry,
+  };
+
+  return redact(payload, redactedKeys);
+}
+
+function stringify(payload: Record<string, unknown>): string {
+  return JSON.stringify(payload);
+}
+
+function logToConsole(level: Exclude<LogLevel, 'silent'>, payload: Record<string, unknown>) {
+  const message = stringify(payload);
+  const consoleMethod = LEVEL_TO_CONSOLE[level];
+  if (typeof console !== 'undefined' && typeof console[consoleMethod] === 'function') {
+    console[consoleMethod](message);
+  }
+}
+
+export default function pino(options: PinoOptions = {}): Logger {
+  let currentLevel: LogLevel = options.level ?? 'info';
+  const base = options.base ?? {};
+  const redactedKeys = options.redact ?? [];
+
+  const bindings: Record<string, unknown> = {};
+
+  const shouldLog = (level: LogLevel) => LEVEL_WEIGHT[level] >= LEVEL_WEIGHT[currentLevel];
+
+  const emit = (level: Exclude<LogLevel, 'silent'>, messageOrData?: LogInput, maybeDataOrMessage?: LogInput) => {
+    if (!shouldLog(level)) {
+      return;
+    }
+
+    const first = normalizeInput(messageOrData);
+    const second = normalizeInput(maybeDataOrMessage);
+
+    let entry: Record<string, unknown> = {};
+    if (first && second) {
+      entry = { ...first, ...second };
+    } else if (first) {
+      entry = first;
+    } else if (second) {
+      entry = second;
+    }
+
+    const payload = mergeObjects(base, bindings, { ...entry, level }, redactedKeys);
+    logToConsole(level, payload);
+  };
+
+  const child = (childBindings: Record<string, unknown>): Logger => {
+    const nextLogger = pino({
+      level: currentLevel,
+      base: { ...base, ...bindings, ...childBindings },
+      redact: redactedKeys,
+    });
+    return nextLogger;
+  };
+
+  return {
+    get level() {
+      return currentLevel;
+    },
+    set level(next) {
+      currentLevel = next;
+    },
+    fatal: (messageOrData, maybeDataOrMessage) => emit('fatal', messageOrData, maybeDataOrMessage),
+    error: (messageOrData, maybeDataOrMessage) => emit('error', messageOrData, maybeDataOrMessage),
+    warn: (messageOrData, maybeDataOrMessage) => emit('warn', messageOrData, maybeDataOrMessage),
+    info: (messageOrData, maybeDataOrMessage) => emit('info', messageOrData, maybeDataOrMessage),
+    debug: (messageOrData, maybeDataOrMessage) => emit('debug', messageOrData, maybeDataOrMessage),
+    trace: (messageOrData, maybeDataOrMessage) => emit('trace', messageOrData, maybeDataOrMessage),
+    child,
+  } as Logger;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "pino": ["./lib/vendor/pino"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- add a lightweight pino-style logger and TypeScript path alias
- replace console logging with structured logger calls across API routes and client utilities
- document JSON logging usage and configuration for development and production

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d3fc6aa1e48324a15a259f398f8fd8